### PR TITLE
Update 2022-08-30-routed-angular-dialogs.md

### DIFF
--- a/_posts/2022-08-30-routed-angular-dialogs.md
+++ b/_posts/2022-08-30-routed-angular-dialogs.md
@@ -86,7 +86,7 @@ I'm not a huge fan of using libraries to do that for us (Except Angular Material
 In this approach we would create a service that handles the creation and destruction of these dialogs for us.
 We could use the approach of my previous article I just mentioned, but it would be better to use the `Angular Material CDK` for that.
 I'm not going into detail for this approach since it's out of scope for this article, but the developer would be in charge of the lifecycle of
-that component. The developer should always manually create the dialog and always manually destroy that dalog.
+that component. The developer should always manually create the dialog and always manually destroy that dialog.
 
 For confirmation-dialogs one could recommend this approach but for more complex dialogs it might be better to have something that
 takes care of the lifecycle of our dialogs automatically.
@@ -235,7 +235,7 @@ we are dealing with 2 nested `router-outlet`'s.
 export class AppModule {}
 ```
 
-That's it. When product management decides that the details of a user should not be shown in a dialog but in a page
+That's it. When product management decides that the details of a user should not be shown in a dialog but on a page
 we should have minimal work to make that happen. We can refresh the page when we want and we don't have to worry
 about the lifecycle of our dialogs.
 


### PR DESCRIPTION
💯 to use the URL to render dialogs.

I spotted a small typo, but the reason why I created this PR is to mention that there's also a [dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) HTML element, which I prefer over the `div`.

I also liked the mentioning of a use case for the first solution (confirmation dialogs), I think it would be useful if you could add that as a separate section on the same level as the advantages and disadvantages. This would only make sense if we could add a use case for each solution though. 